### PR TITLE
Indexer rework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,14 @@ zstd = "0.11.2"
 deku = "0.13.1"
 positioned-io = "0.3"
 
+[profile.release]
+overflow-checks = true # allow to easily spot bugs with the indexer
+debug-assertions = true # allow to easily spot bugs with the indexer
 
 [profile.dhat] # for profiling only # dhat
 inherits = "release"
 debug = 1
+features = ["dhat"]
 
 [[bin]]
 name = "syzygy-check"

--- a/src/bin/syzygy_check.rs
+++ b/src/bin/syzygy_check.rs
@@ -16,7 +16,7 @@ use retroboard::{
 };
 
 use helpmate_tb::{
-    to_chess_with_illegal_checks, Common, Descendants, Generator, Material, PosHandler, Queue,
+    to_chess_with_illegal_checks, Common, Descendants, Generator, Material, PosHandler, Queue, IndexWithTurn,
 };
 
 type Transfo = (
@@ -67,7 +67,7 @@ impl PosHandler for SyzygyCheck {
         _: &mut Queue,
         _: &Descendants,
         chess: &Chess,
-        _: u64,
+        _: IndexWithTurn,
         all_pos_idx: usize,
     ) {
         self.max_index = std::cmp::max(self.max_index, all_pos_idx);

--- a/src/bin/syzygy_check.rs
+++ b/src/bin/syzygy_check.rs
@@ -100,7 +100,7 @@ fn check_mat(mat: Material) {
     let mut gen = Generator::new_with_pos_handler(SyzygyCheck::default(), common);
     gen.generate_positions();
     let (_, _, syzygy_res) = gen.get_result();
-    if syzygy_res.duplicate_indexes.len() > 0 {
+    if !syzygy_res.duplicate_indexes.is_empty() {
         warn!(
             "For {:?}, Found {:?} duplicates",
             mat,

--- a/src/bin/syzygy_check.rs
+++ b/src/bin/syzygy_check.rs
@@ -216,7 +216,7 @@ mod tests {
             &mut Queue::default(),
             &Descendants::empty(),
             &chess,
-            0, // not used
+            IndexWithTurn { idx: 0, turn: Color::White }, // not used
             all_pos_idx,
         );
         assert_eq!(syzygy_check.max_index, 1907795);

--- a/src/bin/syzygy_check.rs
+++ b/src/bin/syzygy_check.rs
@@ -16,7 +16,8 @@ use retroboard::{
 };
 
 use helpmate_tb::{
-    to_chess_with_illegal_checks, Common, Descendants, Generator, Material, PosHandler, Queue, IndexWithTurn,
+    to_chess_with_illegal_checks, Common, Descendants, Generator, IndexWithTurn, Material,
+    PosHandler, Queue,
 };
 
 type Transfo = (
@@ -216,7 +217,10 @@ mod tests {
             &mut Queue::default(),
             &Descendants::empty(),
             &chess,
-            IndexWithTurn { idx: 0, turn: Color::White }, // not used
+            IndexWithTurn {
+                idx: 0,
+                turn: Color::White,
+            }, // not used
             all_pos_idx,
         );
         assert_eq!(syzygy_check.max_index, 1907795);

--- a/src/common.rs
+++ b/src/common.rs
@@ -14,6 +14,7 @@ pub struct Common {
 }
 
 impl Common {
+    #[must_use]
     pub fn new(material: Material, winner: Color) -> Self {
         Self {
             index_table: Table::new(&material),
@@ -25,6 +26,7 @@ impl Common {
         }
     }
 
+    #[must_use]
     pub fn get_progress_bar(&self) -> ProgressBar {
         let pb = ProgressBar::new(get_nb_pos(&self.material));
         pb.set_style(ProgressStyle::default_bar()
@@ -33,10 +35,12 @@ impl Common {
         pb
     }
 
+    #[must_use]
     pub fn can_mate(&self) -> bool {
         self.can_mate
     }
 
+    #[must_use]
     pub fn index_table(&self) -> &Table {
         &self.index_table
     }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -10,7 +10,7 @@ use zstd::stream::{decode_all, encode_all};
 use crate::{OutcomeU8, Outcomes, Report, ReportU8, Reports, ReportsSlice};
 
 // in byte, the size of the uncompressed block we want
-const BLOCK_SIZE: usize = 500 * 1000000;
+const BLOCK_SIZE: usize = 500 * 1_000_000;
 
 // number of elements we take from `outcomes`
 // We want the uncompressed size of a block to be ~500Mb (arbitrary size)

--- a/src/file_handler.rs
+++ b/src/file_handler.rs
@@ -34,6 +34,7 @@ pub struct MaterialWinner<'a> {
 }
 
 impl<'a> MaterialWinner<'a> {
+    #[must_use]
     pub fn new(material: &'a Material, winner: Color) -> Self {
         Self { material, winner }
     }
@@ -56,6 +57,7 @@ impl fmt::Debug for MaterialWinner<'_> {
 pub struct Descendants(HashMap<Material, ByColor<FileHandler>>);
 
 impl Descendants {
+    #[must_use]
     pub fn new(mat: &Material) -> Self {
         Self(
             mat.descendants_not_draw()
@@ -73,6 +75,7 @@ impl Descendants {
     }
 
     // For test purpose
+    #[must_use]
     pub fn empty() -> Self {
         Self(HashMap::new())
     }
@@ -98,7 +101,8 @@ impl Descendants {
     /// For the given position, compute all moves that are either captures and/or promotion,
     /// and return the best result
     /// Example:
-    /// "KPvRK" where the pawn can take and promote then mate in 4, or just promote and mate in 2, will return `Outcome::Win(2)`
+    /// "`KPvRK`" where the pawn can take and promote then mate in 4, or just promote and mate in 2, will return `Outcome::Win(2)`
+    #[must_use]
     pub fn outcome_from_captures_promotion(&self, pos: &Chess, winner: Color) -> Option<Outcome> {
         let mut moves = pos.legal_moves();
         moves.retain(|m| m.is_capture() || m.is_promotion());

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -231,10 +231,10 @@ impl<T: PosHandler> Generator<T> {
             // by convention the former piece put on the board
             // should have a "higher" square than the later to avoid
             // generating the same position but with identical pieces swapped
-            let bb_squares_inf = Bitboard::from_iter(
+            
+            Bitboard::from_iter(
                 (0..last_square.into()).map(unsafe { |sq| Square::new_unchecked(sq) }),
-            );
-            bb_squares_inf
+            )
         }
         // Do not restrict duplicate pieces as they already have other constraints
         // and combining with this one resulting in the generating function not to be surjective anymore
@@ -383,7 +383,7 @@ impl Tagger {
         // all positions that are unknown at the end are drawn
         for report_bc in self.common.all_pos.iter_mut() {
             for report in report_bc.iter_mut() {
-                if Report::Unprocessed(Outcome::Unknown) == Report::from(report.clone()) {
+                if Report::Unprocessed(Outcome::Unknown) == Report::from(*report) {
                     *report = ReportU8::from(Report::Processed(Outcome::Draw))
                 }
             }

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -93,7 +93,7 @@ pub struct Queue {
     pub losing_pos_to_process: VecDeque<u64>,
 }
 
-const A1_H1_H8: Bitboard = Bitboard(0x80c0e0f0f8fcfeff);
+pub const A1_H1_H8: Bitboard = Bitboard(0x80c0e0f0f8fcfeff);
 // const A8_A2_H7: Bitboard = A1_H1_H8.flip_diagonal().without_const(A1_H8_DIAG);
 
 // type PosHandler = fn(&mut Common, &mut Queue, &Descendants, &Chess, u64, usize);

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -394,7 +394,7 @@ impl Tagger {
                 }
             }
         }
-        self.pb.finish_with_message("positions processed");
+        self.pb.finish_and_clear();
     }
 }
 

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -1,6 +1,6 @@
 use crate::{
-    index, index_unchecked, restore_from_index, Common, Descendants, Material, Outcome, OutcomeU8,
-    Report, ReportU8, A1_H8_DIAG, UNDEFINED_OUTCOME_BYCOLOR,
+    index, index_unchecked, indexer::A1_D1_D4, restore_from_index, Common, Descendants, Material,
+    Outcome, OutcomeU8, Report, ReportU8, A1_H8_DIAG, UNDEFINED_OUTCOME_BYCOLOR,
 };
 use log::debug;
 use retroboard::shakmaty::{
@@ -281,9 +281,7 @@ impl<T: PosHandler> Generator<T> {
     pub fn generate_positions(&mut self) {
         let piece_vec = self.common.material.pieces_without_white_king();
         self.common.counter = 0;
-        let white_king_bb = Bitboard(135007759); // a1-d1-d4 triangle
-        debug!("{:?}", white_king_bb.0);
-        for white_king_sq in white_king_bb {
+        for white_king_sq in A1_D1_D4 {
             let mut new_setup = Setup::empty();
             new_setup.board.set_piece_at(white_king_sq, White.king());
             self.generate_positions_internal(&piece_vec, new_setup, (White.king(), white_king_sq))

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -15,29 +15,43 @@ use std::collections::VecDeque;
 
 use indicatif::ProgressBar;
 
+pub trait WithBoard {
+    fn board(&self) -> &Board;
+}
+
+impl WithBoard for Board {
+    fn board(&self) -> &Board {
+        self
+    }
+}
+
+impl WithBoard for Chess {
+    fn board(&self) -> &Board {
+        Position::board(self)
+    }
+}
+
+impl WithBoard for RetroBoard {
+    fn board(&self) -> &Board {
+        self.board()
+    }
+}
+
 // Allow to use both `Chess` and `RetroBoard`
-pub trait SideToMove {
+pub trait SideToMove: WithBoard {
     // side to **move**, so opposite of side to unmove
     fn side_to_move(&self) -> Color;
-    fn board(&self) -> &Board;
 }
 
 impl SideToMove for Chess {
     fn side_to_move(&self) -> Color {
         self.turn()
     }
-    fn board(&self) -> &Board {
-        Position::board(self)
-    }
 }
 
 impl SideToMove for RetroBoard {
     fn side_to_move(&self) -> Color {
         !self.retro_turn()
-    }
-
-    fn board(&self) -> &Board {
-        self.board()
     }
 }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -115,7 +115,7 @@ pub fn index_unchecked(b: &impl SideToMove) -> IndexWithTurn {
 pub fn index_unchecked_without_turn(b: &impl WithBoard) -> u64 {
     let mut idx = KK_IDX[TRIANGLE[b.board().king_of(White).expect("white king") as usize] as usize]
         [b.board().king_of(Black).expect("black king") as usize];
-    println!("{idx:?}");
+    debug_assert!(idx < 462, "Corrupted KK index, board: {:?}", b.board());
     for role in [
         Role::Pawn,
         Role::Knight,
@@ -127,7 +127,6 @@ pub fn index_unchecked_without_turn(b: &impl WithBoard) -> u64 {
             for sq in b.board().by_piece(Piece { color, role }) {
                 idx *= 64;
                 idx += sq as u64;
-                println!("{idx:?}");
             }
         }
     }
@@ -160,7 +159,7 @@ pub fn restore_from_index_board(material: &Material, index: u64) -> Board {
             }
         }
     }
-    assert!(idx < 462);
+    debug_assert!(idx < 462, "Corrupted index: {index}");
     let kings_sq = INV_KK_IDX[idx as usize];
     board.set_piece_at(kings_sq.black, Black.king());
     board.set_piece_at(kings_sq.white, White.king());

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -23,7 +23,7 @@ const IMPOSSIBLE_KING_SQ: ByColor<Square> = ByColor {
     black: Square::H8,
 };
 
-const fn invert_kk_idx(kk_idx: [[u64; 64]; 10]) -> [ByColor<Square>; 462] {
+const fn invert_kk_idx(kk_idx: &[[u64; 64]; 10]) -> [ByColor<Square>; 462] {
     let mut res: [ByColor<Square>; 462] = [IMPOSSIBLE_KING_SQ; 462];
     let mut white_king_sq: usize = 0;
     loop {
@@ -53,7 +53,7 @@ const fn invert_kk_idx(kk_idx: [[u64; 64]; 10]) -> [ByColor<Square>; 462] {
     res
 }
 
-const INV_KK_IDX: [ByColor<Square>; 462] = invert_kk_idx(KK_IDX);
+const INV_KK_IDX: [ByColor<Square>; 462] = invert_kk_idx(&KK_IDX);
 
 #[rustfmt::skip]
 const WHITE_KING_SQUARES_TO_TRANSFO: [u64; 64] = [

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -67,19 +67,6 @@ const WHITE_KING_SQUARES_TO_TRANSFO: [u64; 64] = [
     5, 5, 5, 5, 6, 6, 6, 6,
 ];
 
-const WHITE_KING_INDEX_TO_SQUARE: [Square; 10] = [
-    Square::A1,
-    Square::B1,
-    Square::C1,
-    Square::D1,
-    Square::B2,
-    Square::C2,
-    Square::D2,
-    Square::C3,
-    Square::D3,
-    Square::D4,
-];
-
 pub fn index(b: &impl WithBoard) -> u64 {
     let mut board_check = b.board().clone();
     let white_king_sq = b.board().king_of(White).expect("white king");
@@ -175,20 +162,6 @@ mod tests {
         for bc in INV_KK_IDX {
             assert!(A1_D1_D4.contains(bc.white))
         }
-    }
-
-    #[test]
-    fn test_white_king_index_to_squares() {
-        assert_eq!(WHITE_KING_INDEX_TO_SQUARE[0], Square::A1);
-        assert_eq!(WHITE_KING_INDEX_TO_SQUARE[1], Square::B1);
-        assert_eq!(WHITE_KING_INDEX_TO_SQUARE[2], Square::C1);
-        assert_eq!(WHITE_KING_INDEX_TO_SQUARE[3], Square::D1);
-        assert_eq!(WHITE_KING_INDEX_TO_SQUARE[4], Square::B2);
-        assert_eq!(WHITE_KING_INDEX_TO_SQUARE[5], Square::C2);
-        assert_eq!(WHITE_KING_INDEX_TO_SQUARE[6], Square::D2);
-        assert_eq!(WHITE_KING_INDEX_TO_SQUARE[7], Square::C3);
-        assert_eq!(WHITE_KING_INDEX_TO_SQUARE[8], Square::D3);
-        assert_eq!(WHITE_KING_INDEX_TO_SQUARE[9], Square::D4);
     }
 
     fn mat(fen: &str) -> Material {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,5 +1,5 @@
 /// Naive indexer compated to `indexer_syzygy`
-/// It only handles mapping the white king to the A1_D1_D4 triangle and then hardcoding the 462 positions two kings
+/// It only handles mapping the white king to the `A1_D1_D4` triangle and then hardcoding the 462 positions two kings
 /// can have.
 /// It has the benefit of being fast and easily reversible
 use retroboard::shakmaty::{
@@ -8,13 +8,13 @@ use retroboard::shakmaty::{
 };
 
 use crate::{
-    generation::{WithBoard, A1_H1_H8, IndexWithTurn},
+    generation::{IndexWithTurn, WithBoard, A1_H1_H8},
     indexer_syzygy::{INV_TRIANGLE, KK_IDX, TRIANGLE, Z0},
-    Material, A1_H8_DIAG, SideToMove,
+    Material, SideToMove, A1_H8_DIAG,
 };
 use retroboard::RetroBoard;
 
-pub const A1_D1_D4: Bitboard = Bitboard(135007759);
+pub const A1_D1_D4: Bitboard = Bitboard(135_007_759);
 
 // impossible king square setup because by construction the white king
 // should be in the A1_D1_D4 triangle
@@ -70,8 +70,8 @@ const WHITE_KING_SQUARES_TO_TRANSFO: [u64; 64] = [
 pub fn index(b: &impl SideToMove) -> IndexWithTurn {
     let idx = index_without_turn(b);
     IndexWithTurn {
-        idx, 
-        turn: b.side_to_move()
+        idx,
+        turn: b.side_to_move(),
     }
 }
 
@@ -104,13 +104,13 @@ fn index_without_turn(b: &impl WithBoard) -> u64 {
 pub fn index_unchecked(b: &impl SideToMove) -> IndexWithTurn {
     let idx = index_unchecked_without_turn(b);
     IndexWithTurn {
-        idx, 
-        turn: b.side_to_move()
+        idx,
+        turn: b.side_to_move(),
     }
 }
 
 /// ASSUME the white king is in the a1-d1-d4 corner already
-/// If the white king is on the A1_H8 diagonal, the black king MUST BE in the A1_H1_H8 triangle
+/// If the white king is on the `A1_H8` diagonal, the black king MUST BE in the `A1_H1_H8` triangle
 /// Do not take the turn into account the turn
 pub fn index_unchecked_without_turn(b: &impl WithBoard) -> u64 {
     let mut idx = KK_IDX[TRIANGLE[b.board().king_of(White).expect("white king") as usize] as usize]
@@ -124,7 +124,7 @@ pub fn index_unchecked_without_turn(b: &impl WithBoard) -> u64 {
         Role::Queen,
     ] {
         for color in Color::ALL {
-            for sq in b.board().by_piece(Piece { role, color }) {
+            for sq in b.board().by_piece(Piece { color, role }) {
                 idx *= 64;
                 idx += sq as u64;
                 println!("{idx:?}");
@@ -134,6 +134,7 @@ pub fn index_unchecked_without_turn(b: &impl WithBoard) -> u64 {
     idx
 }
 
+#[must_use]
 pub fn restore_from_index(material: &Material, index: IndexWithTurn) -> RetroBoard {
     let mut setup = Setup::empty();
     setup.board = restore_from_index_board(material, index.idx);
@@ -152,7 +153,7 @@ pub fn restore_from_index_board(material: &Material, index: u64) -> Board {
         Role::Pawn,
     ] {
         for color in [Black, White] {
-            let piece = Piece { role, color };
+            let piece = Piece { color, role };
             for _ in 0..material.by_piece(piece) {
                 board.set_piece_at(unsafe { Square::new_unchecked((idx % 64) as u32) }, piece);
                 idx /= 64;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -188,7 +188,7 @@ mod tests {
         let high_value_board = RetroBoard::new_no_pockets("3BNQQk/8/8/8/3K4/8/8/8 b - -").unwrap();
         let idx = index_unchecked(&high_value_board);
         let config = mat("KBNQQvK");
-        let high_value_from_idx = restore_from_index_board(&config, idx);
+        let high_value_from_idx = restore_from_index_board(&config, idx.idx);
         assert_eq!(high_value_board.board(), &high_value_from_idx);
     }
 
@@ -197,7 +197,7 @@ mod tests {
         let two_kings = RetroBoard::new_no_pockets("8/7k/8/8/3K4/8/8/8 b").unwrap();
         let idx = index_unchecked(&two_kings);
         let config = mat("KvK");
-        let two_kings_from_idx = restore_from_index_board(&config, idx);
+        let two_kings_from_idx = restore_from_index_board(&config, idx.idx);
         assert_eq!(two_kings.board(), &two_kings_from_idx);
     }
 
@@ -210,8 +210,8 @@ mod tests {
         let idx_swapped = index_unchecked(&knights_color_swapped);
         assert_ne!(idx, idx_swapped);
         let config = mat("KBNvKN");
-        let knights_from_idx = restore_from_index_board(&config, idx);
-        let knights_swapped_from_idx = restore_from_index_board(&config, idx_swapped);
+        let knights_from_idx = restore_from_index_board(&config, idx.idx);
+        let knights_swapped_from_idx = restore_from_index_board(&config, idx_swapped.idx);
         assert_eq!(knights.board(), &knights_from_idx);
         assert_eq!(knights_color_swapped.board(), &knights_swapped_from_idx);
     }
@@ -238,7 +238,7 @@ mod tests {
             println!("{rboard:?}");
             let idx = index(&rboard);
             let config = mat("KvK");
-            let rboard_restored = restore_from_index_board(&config, idx);
+            let rboard_restored = restore_from_index_board(&config, idx.idx);
             let white_king_bb = Bitboard::EMPTY
                 | Square::A1
                 | Square::B1

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -9,7 +9,7 @@ use retroboard::shakmaty::{
 
 use crate::{
     generation::{WithBoard, A1_H1_H8},
-    indexer_syzygy::{KK_IDX, TRIANGLE, Z0},
+    indexer_syzygy::{KK_IDX, TRIANGLE, Z0, INV_TRIANGLE},
     Material, A1_H8_DIAG,
 };
 use retroboard::RetroBoard;
@@ -25,16 +25,16 @@ const IMPOSSIBLE_KING_SQ: ByColor<Square> = ByColor {
 
 const fn invert_kk_idx(kk_idx: [[u64; 64]; 10]) -> [ByColor<Square>; 462] {
     let mut res: [ByColor<Square>; 462] = [IMPOSSIBLE_KING_SQ; 462];
-    let mut white_king_sq: u32 = 0;
+    let mut white_king_sq: usize = 0;
     loop {
         // for loops not available in const context
-        let mut black_king_sq: u32 = 0;
+        let mut black_king_sq: usize = 0;
         loop {
-            let idx = kk_idx[white_king_sq as usize][black_king_sq as usize];
+            let idx = kk_idx[white_king_sq as usize][black_king_sq];
             if idx != Z0 {
                 res[idx as usize] = ByColor {
-                    white: WHITE_KING_INDEX_TO_SQUARE[white_king_sq as usize],
-                    black: Square::new(black_king_sq),
+                    white: Square::new(INV_TRIANGLE[white_king_sq] as u32),
+                    black: Square::new(black_king_sq as u32),
                 }
             }
 
@@ -196,13 +196,11 @@ mod tests {
     }
 
     #[test]
-    fn test_index_unchecked_overflow() {
+    fn test_index_unchecked_high_value_index() {
         let high_value_board = RetroBoard::new_no_pockets("3BNQQk/8/8/8/3K4/8/8/8 b - -").unwrap();
         let idx = index_unchecked(&high_value_board);
         let config = mat("KBNQQvK");
-        println!("{config:?}");
         let high_value_from_idx = restore_from_index_board(&config, idx);
-        assert_eq!(idx, 21474033534);
         assert_eq!(high_value_board.board(), &high_value_from_idx);
     }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -9,7 +9,7 @@ use retroboard::shakmaty::{
 
 use crate::{
     generation::{WithBoard, A1_H1_H8},
-    indexer_syzygy::{KK_IDX, TRIANGLE, Z0, INV_TRIANGLE},
+    indexer_syzygy::{INV_TRIANGLE, KK_IDX, TRIANGLE, Z0},
     Material, A1_H8_DIAG,
 };
 use retroboard::RetroBoard;
@@ -97,8 +97,7 @@ pub fn index(b: &impl WithBoard) -> u64 {
 /// If the white king is on the A1_H8 diagonal, the black king MUST BE in the A1_H1_H8 triangle
 /// Do not take the turn into account the turn
 pub fn index_unchecked(b: &impl WithBoard) -> u64 {
-    let mut idx = KK_IDX
-        [TRIANGLE[b.board().king_of(White).expect("white king") as usize] as usize]
+    let mut idx = KK_IDX[TRIANGLE[b.board().king_of(White).expect("white king") as usize] as usize]
         [b.board().king_of(Black).expect("black king") as usize];
     println!("{idx:?}");
     for role in [

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,4 +1,4 @@
-use std::collections::hash_map;
+
 
 /// Naive indexer compated to `indexer_syzygy`
 /// It only handles mapping the white king to the A1_D1_D4 triangle and then hardcoding the 462 positions two kings

--- a/src/indexer_syzygy.rs
+++ b/src/indexer_syzygy.rs
@@ -25,7 +25,7 @@ const MAX_PIECES: usize = 7;
 
 /// Maps squares into the a1-d1-d4 triangle.
 #[rustfmt::skip]
-const TRIANGLE: [u64; 64] = [
+pub const TRIANGLE: [u64; 64] = [
     6, 0, 1, 2, 2, 1, 0, 6,
     0, 7, 3, 4, 4, 3, 7, 0,
     1, 3, 8, 5, 5, 8, 3, 1,

--- a/src/indexer_syzygy.rs
+++ b/src/indexer_syzygy.rs
@@ -262,8 +262,8 @@ const PP_IDX: [[u64; 64]; 10] = [[
 /// The a7-a5-c5 triangle.
 const TEST45: Bitboard = Bitboard(0x1_0307_0000_0000);
 
-pub const A1_H8_DIAG: Bitboard = Bitboard(0x8040201008040201);
-pub const A8_H1_DIAG: Bitboard = Bitboard(0x102040810204080);
+pub const A1_H8_DIAG: Bitboard = Bitboard(0x8040_2010_0804_0201);
+pub const A8_H1_DIAG: Bitboard = Bitboard(0x0102_0408_1020_4080);
 
 const CONSTS: Consts = Consts::new();
 
@@ -452,6 +452,7 @@ impl GroupData {
 }
 
 impl Table {
+    #[must_use]
     pub fn new(material: &Material) -> Self {
         let material_info = get_info_table(material).unwrap();
         let files: ArrayVec<ArrayVec<GroupData, 2>, 4> = material_info
@@ -731,7 +732,7 @@ impl Table {
             material.by_color.white.has_pawns() && material.by_color.black.has_pawns();
         let mut next = 1;
         let mut group_sq = side.lens[0];
-        for lens in side.lens.iter().cloned().skip(1) {
+        for lens in side.lens.iter().copied().skip(1) {
             let (prev_squares, group_squares) = squares.split_at_mut(group_sq);
             let group_squares = &mut group_squares[..lens];
             group_squares.sort_unstable();
@@ -765,8 +766,8 @@ mod tests {
 
     #[test]
     fn test_bb() {
-        assert_eq!(A1_H8_DIAG, Bitboard(9241421688590303745));
-        assert_eq!(A8_H1_DIAG, Bitboard(72624976668147840));
+        assert_eq!(A1_H8_DIAG, Bitboard(9_241_421_688_590_303_745));
+        assert_eq!(A8_H1_DIAG, Bitboard(72_624_976_668_147_840));
     }
 
     #[test]
@@ -778,7 +779,7 @@ mod tests {
             .into_position(CastlingMode::Chess960)
             .unwrap();
         let idx = table.encode(&chess);
-        assert_eq!(idx, 484157);
+        assert_eq!(idx, 484_157);
     }
 
     #[test]
@@ -790,7 +791,7 @@ mod tests {
             .into_position(CastlingMode::Chess960)
             .unwrap();
         let idx = table.encode(&chess);
-        assert_eq!(idx, 1907795);
+        assert_eq!(idx, 1_907_795);
     }
 
     #[test]
@@ -802,9 +803,9 @@ mod tests {
             .into_position(CastlingMode::Chess960)
             .unwrap();
         let idx = table.encode(&chess);
-        assert_eq!(idx, 1907815); // should really be 1907795
-                                  // the patch for this position was reverted because it introduced
-                                  // test_encode_recognised_symetry_syzygy_index_3bis
+        assert_eq!(idx, 1_907_815); // should really be 1907795
+                                    // the patch for this position was reverted because it introduced
+                                    // test_encode_recognised_symetry_syzygy_index_3bis
     }
 
     #[test]
@@ -816,7 +817,7 @@ mod tests {
             .into_position(CastlingMode::Chess960)
             .unwrap();
         let idx = table.encode(&chess);
-        assert_eq!(idx, 242414);
+        assert_eq!(idx, 242_414);
     }
 
     #[test]
@@ -828,7 +829,7 @@ mod tests {
             .into_position(CastlingMode::Chess960)
             .unwrap();
         let idx = table.encode(&chess);
-        assert_eq!(idx, 242414);
+        assert_eq!(idx, 242_414);
     }
 
     #[test]
@@ -840,7 +841,7 @@ mod tests {
             .into_position(CastlingMode::Chess960)
             .unwrap();
         let idx = table.encode(&chess);
-        assert_eq!(idx, 544235);
+        assert_eq!(idx, 544_235);
     }
 
     // same position as in _3, but flipped on the vertical axis
@@ -853,7 +854,7 @@ mod tests {
             .into_position(CastlingMode::Chess960)
             .unwrap();
         let idx = table.encode(&chess);
-        assert_eq!(idx, 544235);
+        assert_eq!(idx, 544_235);
     }
 
     #[test]
@@ -871,8 +872,8 @@ mod tests {
             .unwrap();
         let idx = table.encode(&chess);
         let idx_2 = table.encode(&chess_2);
-        assert_eq!(idx, 1907429);
-        assert_eq!(idx_2, 1907795);
+        assert_eq!(idx, 1_907_429);
+        assert_eq!(idx_2, 1_907_795);
     }
 
     #[test]
@@ -925,7 +926,7 @@ mod tests {
             .unwrap();
         let idx_1 = table.encode(&chess_1);
         let idx_2 = table.encode(&chess_2);
-        assert_eq!(idx_1, 325388);
-        assert_eq!(idx_2, 325388);
+        assert_eq!(idx_1, 325_388);
+        assert_eq!(idx_2, 325_388);
     }
 }

--- a/src/indexer_syzygy.rs
+++ b/src/indexer_syzygy.rs
@@ -69,11 +69,11 @@ const MULT_TWIST: [u64; 64] = [
 
 /// Unused entry. Initialized to `-1`, so that most uses will cause noticable
 /// overflow in debug mode.
-const Z0: u64 = u64::max_value();
+pub const Z0: u64 = u64::max_value();
 
 /// Encoding of all 462 configurations of two not-connected kings.
 #[rustfmt::skip]
-const KK_IDX: [[u64; 64]; 10] = [[
+pub const KK_IDX: [[u64; 64]; 10] = [[
      Z0,  Z0,  Z0,   0,   1,   2,   3,   4,
      Z0,  Z0,  Z0,   5,   6,   7,   8,   9,
      10,  11,  12,  13,  14,  15,  16,  17,

--- a/src/indexer_syzygy.rs
+++ b/src/indexer_syzygy.rs
@@ -462,11 +462,7 @@ impl Table {
                 infos
                     .iter()
                     .map(|side| {
-                        GroupData::new(
-                            ArrayVec::from_iter(side.pieces.clone().into_iter()),
-                            side.order,
-                            file,
-                        )
+                        GroupData::new(side.pieces.clone().into_iter().collect(), side.order, file)
                     })
                     .collect()
             })
@@ -490,6 +486,8 @@ impl Table {
 
     /// Given a position, determine the unique (modulo symmetries) index into
     /// the corresponding subtable.
+    #[allow(clippy::similar_names)] // changing names would make comparison with upstream more difficult
+    #[allow(clippy::too_many_lines)] // same for refactoring
     pub fn encode_checked(&self, pos: &impl SideToMove) -> Option<usize> {
         let material = Material::from_board(pos.board());
 

--- a/src/indexer_syzygy.rs
+++ b/src/indexer_syzygy.rs
@@ -39,7 +39,7 @@ pub const TRIANGLE: [u64; 64] = [
 pub type Pieces = ArrayVec<Piece, MAX_PIECES>;
 
 /// Inverse of `TRIANGLE`.
-const INV_TRIANGLE: [usize; 10] = [1, 2, 3, 10, 11, 19, 0, 9, 18, 27];
+pub const INV_TRIANGLE: [usize; 10] = [1, 2, 3, 10, 11, 19, 0, 9, 18, 27];
 
 /// Maps the b1-h1-h7 triangle to `0..=27`.
 #[rustfmt::skip]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub use compression::EncoderDecoder;
 pub use encoding::get_info_table;
 pub use generation::{
     to_chess_with_illegal_checks, Generator, PosHandler, Queue, SideToMove, SideToMoveGetter,
-    TableBaseBuilder,
+    TableBaseBuilder, IndexWithTurn
 };
 pub use indexer::{index, index_unchecked, restore_from_index};
 pub use indexer_syzygy::{Pieces, Table, A1_H8_DIAG, A8_H1_DIAG};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::pedantic)]
+
 mod common;
 mod compression;
 mod encoding;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@ pub use crate::outcome::{
 pub use compression::EncoderDecoder;
 pub use encoding::get_info_table;
 pub use generation::{
-    to_chess_with_illegal_checks, Generator, PosHandler, Queue, SideToMove, SideToMoveGetter,
-    TableBaseBuilder, IndexWithTurn
+    to_chess_with_illegal_checks, Generator, IndexWithTurn, PosHandler, Queue, SideToMove,
+    SideToMoveGetter, TableBaseBuilder,
 };
 pub use indexer::{index, index_unchecked, restore_from_index};
 pub use indexer_syzygy::{Pieces, Table, A1_H8_DIAG, A8_H1_DIAG};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,10 @@
 #![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_panics_doc,
+    clippy::missing_errors_doc,
+    clippy::cast_possible_truncation,
+    clippy::semicolon_if_nothing_returned // should be machine applicable
+)]
 
 mod common;
 mod compression;

--- a/src/material.rs
+++ b/src/material.rs
@@ -31,6 +31,7 @@ use std::iter;
 
 use serde::de;
 
+#[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct MaterialSide {
     by_role: ByRole<u8>,
@@ -189,6 +190,7 @@ impl fmt::Debug for MaterialSide {
 /// Wrapper to ensure `Material` is always normalised
 /// There should be no way to mutate it, and only one way to create it:
 /// `From<ByColor<MaterialSide>>`
+#[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct ByColorNormalisedMaterialSide(ByColor<MaterialSide>);
 
@@ -207,6 +209,7 @@ impl Deref for ByColorNormalisedMaterialSide {
 }
 
 /// A material key.
+#[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct Material {
     pub by_color: ByColorNormalisedMaterialSide,

--- a/src/material.rs
+++ b/src/material.rs
@@ -432,15 +432,32 @@ impl Material {
         *self.by_color.get(piece.color).get(piece.role)
     }
 
+    // yield the kings of both color first, then all white pieces, then all black pieces
     fn pieces_with_white_king(&self, with_white_king: bool) -> Pieces {
         let mut pieces = Pieces::new();
         for color in Color::ALL {
-            for role in Role::ALL {
+            let piece = Piece {
+                color,
+                role: Role::King,
+            };
+            if with_white_king || !(piece == Color::White.king()) {
+                for _ in 0..self.by_piece(piece) {
+                    pieces.push(piece)
+                }
+            }
+        }
+        for color in Color::ALL {
+            // important to have the kings first for indexing
+            for role in [
+                Role::Pawn,
+                Role::Knight,
+                Role::Bishop,
+                Role::Rook,
+                Role::Queen,
+            ] {
                 let piece = Piece { color, role };
-                if with_white_king || !(piece == Color::White.king()) {
-                    for _ in 0..self.by_piece(piece) {
-                        pieces.push(piece)
-                    }
+                for _ in 0..self.by_piece(piece) {
+                    pieces.push(piece)
                 }
             }
         }
@@ -510,11 +527,11 @@ mod tests {
     fn test_pieces_without_white_king_from_material() {
         let mat = Material::from_str("KRQvKBN").unwrap();
         let pieces: Pieces = (&[
+            Black.king(),
             White.rook(),
             White.queen(),
             Black.knight(),
             Black.bishop(),
-            Black.king(),
         ] as &[_])
             .try_into()
             .unwrap();

--- a/src/material.rs
+++ b/src/material.rs
@@ -134,6 +134,7 @@ impl MaterialSide {
     }
 }
 
+#[must_use]
 pub fn is_black_stronger(board: &Board) -> bool {
     MaterialSide::from(board.material_side(Color::Black))
         > MaterialSide::from(board.material_side(Color::White))
@@ -277,6 +278,7 @@ pub const KN_K: Material = Material {
 
 impl Material {
     /// Get the material configuration for a [`Board`].
+    #[must_use]
     pub fn from_board(board: &Board) -> Self {
         Self {
             by_color: ByColor::new_with(|color| MaterialSide {
@@ -287,6 +289,7 @@ impl Material {
     }
 
     #[allow(clippy::should_implement_trait)] // no idea how to rename, but don't want to have it return a result
+    #[must_use]
     pub fn from_str(s: &str) -> Option<Self> {
         if s.len() > 64 + 1 {
             return None;
@@ -302,22 +305,27 @@ impl Material {
         })
     }
 
+    #[must_use]
     pub fn count(&self) -> usize {
-        self.by_color.iter().map(|side| side.count()).sum()
+        self.by_color.iter().map(MaterialSide::count).sum()
     }
 
+    #[must_use]
     pub fn is_symmetric(&self) -> bool {
         self.by_color.white == self.by_color.black
     }
 
+    #[must_use]
     pub fn has_pawns(&self) -> bool {
-        self.by_color.iter().any(|side| side.has_pawns())
+        self.by_color.iter().any(MaterialSide::has_pawns)
     }
 
+    #[must_use]
     pub fn unique_pieces(&self) -> u8 {
-        self.by_color.iter().map(|side| side.unique_roles()).sum()
+        self.by_color.iter().map(MaterialSide::unique_roles).sum()
     }
 
+    #[must_use]
     pub fn min_like_man(&self) -> u8 {
         self.by_color
             .iter()
@@ -330,6 +338,7 @@ impl Material {
 
     /// For any color
     // TODO is this actually needed or the only material configurations where no color can mate are "KvK", "KBvK" and "KNvK"?
+    #[must_use]
     pub fn is_mate_possible(&self) -> bool {
         // order is arbitrary
         let (white, black) = (
@@ -339,6 +348,7 @@ impl Material {
         white.is_mate_possible(black)
     }
 
+    #[must_use]
     pub fn can_mate(&self, color: Color) -> bool {
         let my_side = self.by_color.get(color);
         let opposite_side = self.by_color.get(!color);
@@ -392,6 +402,7 @@ impl Material {
 
     /// Vec containing all unique material configurations not containing the root material.
     /// Sorted by positions with fewer pieces first
+    #[must_use]
     pub fn descendants_recursive(&self, include_drawn_materials: bool) -> Vec<Self> {
         let mut descendants_recursive: Vec<Self> =
             self.descendants_recursive_internal(include_drawn_materials);
@@ -413,6 +424,7 @@ impl Material {
             .collect()
     }
 
+    #[must_use]
     pub fn by_piece(&self, piece: Piece) -> u8 {
         *self.by_color.get(piece.color).get(piece.role)
     }
@@ -432,6 +444,7 @@ impl Material {
         pieces
     }
 
+    #[must_use]
     pub fn pieces_without_white_king(&self) -> Pieces {
         self.pieces_with_white_king(false)
     }

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -56,8 +56,7 @@ impl Report {
     #[must_use]
     pub fn outcome(&self) -> Outcome {
         match self {
-            Self::Unprocessed(outcome) => *outcome,
-            Self::Processed(outcome) => *outcome,
+            Self::Unprocessed(outcome) | Self::Processed(outcome) => *outcome,
         }
     }
 }
@@ -124,6 +123,8 @@ impl From<&OutcomeU8> for Outcome {
 }
 
 impl Ord for Outcome {
+
+    #[allow(clippy::match_same_arms)] // clearer to follow the flow even if there is some duplicates here
     fn cmp(&self, other: &Self) -> Ordering {
         match (self, other) {
             (Self::Undefined, _) | (_, Self::Undefined) => {

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use std::ops::Add;
 use std::ops::Not;
 
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct OutcomeOutOfBound;
 
@@ -31,6 +32,7 @@ impl ReportU8 {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 #[repr(transparent)]
 #[derive(Debug, Clone, Eq, PartialEq, Copy, Hash)]
 pub struct OutcomeU8(u8);
@@ -87,6 +89,7 @@ impl From<&ReportU8> for Report {
 }
 
 /// According to winnner set in `Generator`. This struct need to fit in a u7
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Eq, PartialEq, Copy, Hash)]
 pub enum Outcome {
     // TODO replace by an enum with 63 elements?
@@ -123,7 +126,6 @@ impl From<&OutcomeU8> for Outcome {
 }
 
 impl Ord for Outcome {
-
     #[allow(clippy::match_same_arms)] // clearer to follow the flow even if there is some duplicates here
     fn cmp(&self, other: &Self) -> Ordering {
         match (self, other) {

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -25,6 +25,7 @@ pub enum Report {
 pub struct ReportU8(u8);
 
 impl ReportU8 {
+    #[must_use]
     pub fn from_raw_u8(u: u8) -> Self {
         Self(u)
     }
@@ -35,6 +36,7 @@ impl ReportU8 {
 pub struct OutcomeU8(u8);
 
 impl OutcomeU8 {
+    #[must_use]
     pub fn from_raw_u8(u: u8) -> Option<Self> {
         if u < 128 {
             Some(Self(u))
@@ -43,6 +45,7 @@ impl OutcomeU8 {
         }
     }
 
+    #[must_use]
     pub fn as_raw_u8(&self) -> u8 {
         self.0
     }
@@ -50,6 +53,7 @@ impl OutcomeU8 {
 
 impl Report {
     #[inline]
+    #[must_use]
     pub fn outcome(&self) -> Outcome {
         match self {
             Self::Unprocessed(outcome) => *outcome,


### PR DESCRIPTION
Rework the naive indexer by hard-coding the 462 positions two non-connected kings can take. Also fix clippy warnings, including pedantic ones